### PR TITLE
Change plugin name and depend on 2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'opensearch.pluginzip'
 
 group = 'org.opensearch'
 
-def pluginName = 'search-relevance'
+def pluginName = 'search-processor'
 def pluginDescription = 'Make Opensearch results more relevant.'
 def projectPath = 'org.opensearch'
 def pathToPlugin = 'search.relevance'
@@ -52,7 +52,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "2.1.0-SNAPSHOT"
+        opensearch_version = "2.4.0-SNAPSHOT"
     }
 
     repositories {
@@ -78,10 +78,10 @@ dependencies {
     implementation 'com.ibm.icu:icu4j:57.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.apache.httpcomponents:httpcore:4.4.12'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.13.2'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.15'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.0'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.300'
     implementation 'com.amazonaws:aws-java-sdk-core:1.12.300'

--- a/src/test/java/org/opensearch/search/relevance/SearchRelevancePluginIT.java
+++ b/src/test/java/org/opensearch/search/relevance/SearchRelevancePluginIT.java
@@ -34,6 +34,6 @@ public class SearchRelevancePluginIT extends OpenSearchIntegTestCase {
         String body = EntityUtils.toString(response.getEntity());
 
         logger.info("response body: {}", body);
-        assertThat(body, containsString("search-relevance"));
+        assertThat(body, containsString("search-processor"));
     }
 }

--- a/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -5,4 +5,4 @@
         h: component
 
   - match:
-      $body: /^search-relevance\n$/
+      $body: /^search-processor\n$/


### PR DESCRIPTION
As we get closer to releasing this plugin to work with 2.4, we should update the name -- going with search-processor -- to better reflect the idea that it will be able to transform search requests and responses. Also, we need to update the build to point to 2.4 snapshots, instead of 2.1.

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
* Changes the name of the plugin artifact from `search-relevance` to `search-processor`. (We still need to change the name of the classes, but that's an internal detail, whereas this is the public-facing name of the plugin.)
 * Updates to build against OpenSearch-2.4.0-SNAPSHOT

This commit adds no new functionality.

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
