### PR TITLE
Bug fix: Allow empty title field after tokenization

### DIFF
--- a/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/KendraIntelligentRanker.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/KendraIntelligentRanker.java
@@ -111,6 +111,10 @@ public class KendraIntelligentRanker implements ResultTransformer {
         List<String> tokenizedTitle = null;
         if (queryParserResult.getTitleFieldName() != null) {
           tokenizedTitle = textTokenizer.tokenize(docSourceMap.get(queryParserResult.getTitleFieldName()).toString());
+          // If tokens list is empty, use null
+          if (tokenizedTitle.isEmpty()) {
+            tokenizedTitle = null;
+          }
         }
         for (int i = 0; i < topPassages.size(); i++) {
           originalHits.add(


### PR DESCRIPTION
### Description
If there are no tokens from tokenizing the title field, pass null to Kendra instead of empty list.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
