### PR TITLE
Build against 2.4.0 (without -SNAPSHOT)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "2.4.0-SNAPSHOT"
+        opensearch_version = "2.4.0"
     }
 
     repositories {


### PR DESCRIPTION
Since 2.4.0 is released, we no longer need to build against -SNAPSHOT.

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
Just removes -SNAPSHOT from the OpenSearch version, so we build against the 2.4.0 release.
 
### Issues Resolved
Relates to #27 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
