### PR TITLE
updated pr_stats to point to the APP_PRIVATE_KEY secrey

### DIFF
--- a/.github/workflows/pr_stats.yml
+++ b/.github/workflows/pr_stats.yml
@@ -1,6 +1,8 @@
 name: Pull Request Stats
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   stats:
@@ -8,9 +10,3 @@ jobs:
     steps:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
-        with:
-          token: ${{ secrets.APP_PRIVATE_KEY }}
-          period: 30
-          charts: true
-          disable-links: true
-          sort-by: 'COMMENTS'

--- a/.github/workflows/pr_stats.yml
+++ b/.github/workflows/pr_stats.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.APP_PRIVATE_KEY }}
           period: 30
           charts: true
           disable-links: true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This repository currently hosts a plugin to rerank search results before returni
 # History
 This repository has also been used for discussion and ideas around search relevance. These discussions still exist here, however due to the relatively new standard of having one repo per plugin in OpenSearch and our implementations beginning to make it into the OpenSearch build, we have two repositories now. This repository will develop into a plugin that will allow OpenSearch users to rewrite search queries, rerank results, and log data about those actions. The other repository, [dashboards-search-relevance](https://www.github.com/opensearch-projects/dashboards-search-relevance), is where we will build front-end tooling to help relevance engineers and business users tune results. 
 
+I don't know. Why not?
+
 
 ## Project Resources
 


### PR DESCRIPTION
Signed-off-by: Mark Cohen <markcoh@amazon.com>

### Description
Gives access to the pr_stats.yml action to add pull request stats as comments to the pull request
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
