### PR TITLE
stripped down version of pr stats for only this repository

### DIFF
--- a/.github/workflows/pr_stats.yml
+++ b/.github/workflows/pr_stats.yml
@@ -1,6 +1,8 @@
 name: Pull Request Stats
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   stats:
@@ -8,9 +10,3 @@ jobs:
     steps:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          period: 30
-          charts: true
-          disable-links: true
-          sort-by: 'COMMENTS'


### PR DESCRIPTION
Signed-off-by: Mark Cohen <markcoh@amazon.com>

### Description
This should create a table in the PR comments with stats from the last 30 days of pull requests for this repo only
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
