### PR TITLE
Fix permissions for PR Stats action

### DIFF
--- a/.github/workflows/pr_stats.yml
+++ b/.github/workflows/pr_stats.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   stats:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Run pull request stats
         uses: flowwer-dev/pull-request-stats@master


### PR DESCRIPTION
### Description
The [pull-request-stats](https://github.com/flowwer-dev/pull-request-stats) action is configured correctly but lacks permission to comment on the pull request description.

This pull request sets `write` permission for `pull-requests` on this action.
 
### Issues Resolved
* #66
* [#62 (pull-request-stats)](https://github.com/flowwer-dev/pull-request-stats/issues/62)
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
