### PR TITLE
[Backport 2.x] adding Mingshi Liu as a maintainer to the repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,3 +12,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Lior Perry      | [YANG-DB](https://github.com/YANG-DB)     | Amazon      |
 | Shenoy Pratik   | [ps48](https://github.com/ps48)           | Amazon      |
 | Louis Chu       | [noCharger](https://github.com/noCharger) | Amazon      |
+| Mingshi Liu     | [mingshl](https://github.com/mingshl)     | Amazon      |


### PR DESCRIPTION
Addressing #87 to manually redo the back-porting failed PRs on bot https://github.com/opensearch-project/search-processor/pull/86

adding Mingshi Liu as a maintainer to the repo

(cherry picked from commit 60f6cbbb28c9da412225b1234066ad28fe7d2e29)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
