### PR TITLE
Increment from 2.4 to 2.5 and bump jackson from 2.14.0 to 2.14.1

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "2.4.0" ]
+        bwc_version : [ "2.5.0" ]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
 
     name: SRP Restart-Upgrade BWC Tests
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "2.4.0" ]
+        bwc_version: [ "2.5.0" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]
 
     name: SRP Rolling-Upgrade BWC Tests

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "2.4.0"
+        opensearch_version = "2.5.0"
     }
 
     repositories {
@@ -80,9 +80,9 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.httpcomponents:httpcore:4.4.15'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.1'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.300'
     implementation 'com.amazonaws:aws-java-sdk-core:1.12.300'

--- a/helpers/search_processing_kendra_quickstart.sh
+++ b/helpers/search_processing_kendra_quickstart.sh
@@ -7,7 +7,7 @@ set -o nounset
 
 # Some useful constants
 readonly DOCKER_IMAGE_TAG="opensearch-with-ranking-plugin"
-readonly OPENSEARCH_VERSION="2.4.0"
+readonly OPENSEARCH_VERSION="2.5.0"
 
 #
 # Set default values for OpenSearch (+Dashboards) image tags and plugin URL.


### PR DESCRIPTION
### Description
Increment from 2.4 to 2.5 and bump jackson from 2.14.0 to 2.14.1

During gradle assemble, found a version conflict for jackson packages. It caused by the OpenSearch repo lately upgrade  jackson from 2.14.0 to 2.14.1, thus bumping jackson packages according to resolve version conflict in this pr.

https://github.com/opensearch-project/OpenSearch/blob/main/client/sniffer/licenses/jackson-core-2.14.1.jar.sha1
 
### Issues Resolved
#81 
 
### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).

Signed-off-by: Mingshi Liu <mingshl@amazon.com>
