### PR TITLE
Improve test coverage

### DIFF
--- a/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraHttpClient.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraHttpClient.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
@@ -38,7 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensearch.search.relevance.transformer.kendraintelligentranking.model.dto.RescoreRequest;
 import org.opensearch.search.relevance.transformer.kendraintelligentranking.model.dto.RescoreResult;
 
-public class KendraHttpClient {
+public class KendraHttpClient implements Closeable {
   private static final String KENDRA_RANKING_SERVICE_NAME = "kendra-ranking";
   private static final String KENDRA_RESCORE_URI = "rescore";
   private static final String KENDRA_RESCORE_EXECUTION_PLANS = "rescore-execution-plans";
@@ -131,5 +133,12 @@ public class KendraHttpClient {
 
   public boolean isValid() {
     return StringUtils.isNotEmpty(serviceEndpoint) && StringUtils.isNotEmpty(executionPlanId);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (amazonHttpClient != null) {
+      amazonHttpClient.shutdown();
+    }
   }
 }

--- a/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/configuration/KendraIntelligentRankingConfiguration.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/configuration/KendraIntelligentRankingConfiguration.java
@@ -76,7 +76,7 @@ public class KendraIntelligentRankingConfiguration extends ResultTransformerConf
     this.properties.writeTo(out);
   }
 
-  public static ResultTransformerConfiguration parse(XContentParser parser) throws IOException {
+  public static KendraIntelligentRankingConfiguration parse(XContentParser parser) throws IOException {
     try {
       KendraIntelligentRankingConfiguration configuration = PARSER.parse(parser, null);
       if (configuration != null && configuration.getOrder() <= 0) {
@@ -154,7 +154,7 @@ public class KendraIntelligentRankingConfiguration extends ResultTransformerConf
 
     public KendraIntelligentRankingProperties(StreamInput input) throws IOException {
       this.bodyFields = input.readStringList();
-      this.bodyFields = input.readStringList();
+      this.titleFields = input.readStringList();
       this.docLimit = input.readInt();
     }
 
@@ -195,8 +195,8 @@ public class KendraIntelligentRankingConfiguration extends ResultTransformerConf
 
       KendraIntelligentRankingProperties properties = (KendraIntelligentRankingProperties) o;
 
-      return (bodyFields == properties.bodyFields) && (titleFields == properties.titleFields) &&
-          (docLimit == properties.docLimit);
+      return bodyFields.equals(properties.bodyFields) && titleFields.equals(properties.titleFields) &&
+          docLimit == properties.docLimit;
     }
 
     @Override
@@ -227,5 +227,6 @@ public class KendraIntelligentRankingConfiguration extends ResultTransformerConf
     public void setDocLimit(final int docLimit) {
       this.docLimit = docLimit;
     }
+
   }
 }

--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraHttpClientTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraHttpClientTests.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ */
+
+package org.opensearch.search.relevance.transformer.kendraintelligentranking.client;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.http.IdleConnectionReaper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.net.URI;
+
+public class KendraHttpClientTests extends OpenSearchTestCase {
+
+    public void testCreateClient() throws Exception {
+
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials("accessKey", "secretKey");
+        KendraClientSettings settings = new KendraClientSettings(basicAWSCredentials,
+                "http://localhost",
+                "us-west-2",
+                "12345678",
+                "myAwesomeRole"
+        );
+
+        try (KendraHttpClient client = new KendraHttpClient(settings)) {
+            assertEquals(new URI("http://localhost/rescore-execution-plans/12345678/rescore"), client.buildRescoreURI());
+        }
+        IdleConnectionReaper.shutdown();
+    }
+
+}

--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/configuration/KendraIntelligentRankingConfigurationTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/configuration/KendraIntelligentRankingConfigurationTests.java
@@ -7,17 +7,73 @@
  */
 package org.opensearch.search.relevance.transformer.kendraintelligentranking.configuration;
 
-import org.junit.Test;
+import org.opensearch.common.bytes.BytesReference;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentParser;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.search.relevance.configuration.Constants;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.List;
 
 public class KendraIntelligentRankingConfigurationTests extends OpenSearchTestCase {
-    public void testParseWithNullParserAndContext() {
-        try {
-            KendraIntelligentRankingConfiguration.parse(null);
-            fail();
-        } catch (NullPointerException | IOException e) {
-        }
+    public void testParseWithNullParserAndContext() throws IOException {
+        expectThrows(NullPointerException.class, () -> KendraIntelligentRankingConfiguration.parse(null));
+    }
+
+    public void testSerializeToXContentRoundtrip() throws IOException {
+        KendraIntelligentRankingConfiguration expected = getKendraIntelligentRankingConfiguration();
+
+        XContentType xContentType = randomFrom(XContentType.values());
+        BytesReference serialized = XContentHelper.toXContent(expected, xContentType, true);
+
+        XContentParser parser = createParser(xContentType.xContent(), serialized);
+
+        KendraIntelligentRankingConfiguration deserialized =
+                KendraIntelligentRankingConfiguration.parse(parser);
+        assertEquals(expected, deserialized);
+    }
+
+    public void testSerializeToStreamRoundtrip() throws IOException {
+        KendraIntelligentRankingConfiguration expected = getKendraIntelligentRankingConfiguration();
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        expected.writeTo(bytesStreamOutput);
+
+        KendraIntelligentRankingConfiguration deserialized =
+                new KendraIntelligentRankingConfiguration(bytesStreamOutput.bytes().streamInput());
+        assertEquals(expected, deserialized);
+    }
+
+    private static KendraIntelligentRankingConfiguration getKendraIntelligentRankingConfiguration() {
+        int order = randomInt(10);
+        int docLimit = randomInt( Integer.MAX_VALUE - 25) + 25;
+        KendraIntelligentRankingConfiguration.KendraIntelligentRankingProperties properties =
+                new KendraIntelligentRankingConfiguration.KendraIntelligentRankingProperties(List.of("body1"),
+                        List.of("title1"), docLimit);
+        return new KendraIntelligentRankingConfiguration(order, properties);
+    }
+
+    public void testReadFromSettings() throws IOException {
+        int order = randomInt(10);
+        int docLimit = randomInt(100) + 25;
+        String bodyField = "body1";
+        String titleField = "title1";
+        Settings settings = Settings.builder()
+                .put(Constants.ORDER,  order)
+                .put("properties.doc_limit", docLimit)
+                .put("properties.body_field", bodyField)
+                .putList("properties.title_field", titleField)
+                .build();
+
+        KendraIntelligentRankingConfiguration expected = new KendraIntelligentRankingConfiguration(order,
+                new KendraIntelligentRankingConfiguration.KendraIntelligentRankingProperties(List.of(bodyField),
+                        List.of(titleField), docLimit));
+
+        KendraIntelligentRankingConfiguration actual = new KendraIntelligentRankingConfiguration(settings);
+
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
Added tests for KendraIntelligentRankingConfiguration and KendraHttpClient.

Works toward
https://github.com/opensearch-project/search-processor/issues/31

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
This change adds more test coverage for search-processor, targeting two classes (KendraIntelligentRankingConfiguration and KendraHttpClient) that were contributing the most uncovered lines.
 
### Issues Resolved
#31 
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
