### PR TITLE
Add more test coverage

### DIFF
--- a/src/main/java/org/opensearch/search/relevance/transformer/TransformerType.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/TransformerType.java
@@ -21,12 +21,4 @@ public enum TransformerType {
     return type;
   }
 
-  public static TransformerType fromString(String type) {
-    for (TransformerType transformerType : values()) {
-      if (transformerType.type.equalsIgnoreCase(type)) {
-        return transformerType;
-      }
-    }
-    throw new IllegalArgumentException("Unrecognized Transformer type [" + type + "]");
-  }
 }

--- a/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/KendraIntelligentRankingException.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/KendraIntelligentRankingException.java
@@ -20,11 +20,4 @@ public class KendraIntelligentRankingException extends OpenSearchException {
     super(message);
   }
 
-  public KendraIntelligentRankingException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public KendraIntelligentRankingException(String message, Throwable cause, Object... args) {
-    super(message, cause, args);
-  }
 }

--- a/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/dto/Document.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/dto/Document.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.List;
+import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
 public class Document {
@@ -28,6 +29,12 @@ public class Document {
     this.tokenizedTitle = tokenizedTitle;
     this.tokenizedBody = tokenizedBody;
     this.originalScore = originalScore;
+  }
+
+  /**
+   * No-args constructor used to deserialize.
+   */
+  public Document() {
   }
 
   public String getId() {
@@ -68,5 +75,18 @@ public class Document {
 
   public void setOriginalScore(Float originalScore) {
     this.originalScore = originalScore;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    Document document = (Document) o;
+    return Objects.equals(id, document.id) && Objects.equals(groupId, document.groupId) && Objects.equals(tokenizedTitle, document.tokenizedTitle) && Objects.equals(tokenizedBody, document.tokenizedBody) && Objects.equals(originalScore, document.originalScore);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, groupId, tokenizedTitle, tokenizedBody, originalScore);
   }
 }

--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraClientSettingsTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraClientSettingsTests.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ */
+
+package org.opensearch.search.relevance.transformer.kendraintelligentranking.client;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSSessionCredentials;
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.SecureSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsException;
+import org.opensearch.search.relevance.transformer.kendraintelligentranking.configuration.KendraIntelligentRankerSettings;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class KendraClientSettingsTests extends OpenSearchTestCase {
+
+    private static final String REGION = "us-west-2";
+    private static final String ENDPOINT = "http://localhost";
+    private static final String ACCESS_KEY = "my-access-key";
+    private static final String SECRET_KEY = "my-secret-key";
+    private static final String ASSUMED_ROLE = "assumed-role";
+    private static final String SESSION_TOKEN = "session-token";
+
+
+    private static KendraClientSettings buildClientSettings(boolean withAccessKey, boolean withSecretKey,
+                                                            boolean withSessionToken) throws IOException {
+        try (MockSecureSettings secureSettings = new MockSecureSettings()) {
+            if (withAccessKey) {
+                secureSettings.setString(KendraIntelligentRankerSettings.ACCESS_KEY_SETTING.getKey(), ACCESS_KEY);
+            }
+            if (withSecretKey) {
+                secureSettings.setString(KendraIntelligentRankerSettings.SECRET_KEY_SETTING.getKey(), SECRET_KEY);
+            }
+            if (withSessionToken) {
+                secureSettings.setString(KendraIntelligentRankerSettings.SESSION_TOKEN_SETTING.getKey(), SESSION_TOKEN);
+            }
+            Settings settings = Settings.builder()
+                    .put(KendraIntelligentRankerSettings.SERVICE_REGION_SETTING.getKey(), REGION)
+                    .put(KendraIntelligentRankerSettings.SERVICE_ENDPOINT_SETTING.getKey(), ENDPOINT)
+                    .put(KendraIntelligentRankerSettings.ASSUME_ROLE_ARN_SETTING.getKey(), ASSUMED_ROLE)
+                    .setSecureSettings(secureSettings)
+                    .build();
+
+            return KendraClientSettings.getClientSettings(settings);
+        }
+    }
+
+    public void testWithBasicCredentials() throws IOException {
+        KendraClientSettings clientSettings = buildClientSettings(true, true, false);
+
+        AWSCredentials credentials = clientSettings.getCredentials();
+        assertEquals(ACCESS_KEY, credentials.getAWSAccessKeyId());
+        assertEquals(SECRET_KEY, credentials.getAWSSecretKey());
+        assertFalse(credentials instanceof AWSSessionCredentials);
+        assertEquals(REGION, clientSettings.getServiceRegion());
+        assertEquals(ENDPOINT, clientSettings.getServiceEndpoint());
+        assertEquals(ASSUMED_ROLE, clientSettings.getAssumeRoleArn());
+    }
+
+    public void testWithSessionCredentials() throws IOException {
+        KendraClientSettings clientSettings = buildClientSettings(true, true, true);
+
+        AWSCredentials credentials = clientSettings.getCredentials();
+        assertEquals(ACCESS_KEY, credentials.getAWSAccessKeyId());
+        assertEquals(SECRET_KEY, credentials.getAWSSecretKey());
+        assertTrue(credentials instanceof AWSSessionCredentials);
+        AWSSessionCredentials sessionCredentials = (AWSSessionCredentials) credentials;
+        assertEquals(SESSION_TOKEN, sessionCredentials.getSessionToken());
+        assertEquals(REGION, clientSettings.getServiceRegion());
+        assertEquals(ENDPOINT, clientSettings.getServiceEndpoint());
+        assertEquals(ASSUMED_ROLE, clientSettings.getAssumeRoleArn());
+    }
+
+    public void testWithoutCredentials() throws IOException {
+        KendraClientSettings clientSettings = buildClientSettings(false, false, false);
+
+        assertNull(clientSettings.getCredentials());
+        assertEquals(REGION, clientSettings.getServiceRegion());
+        assertEquals(ENDPOINT, clientSettings.getServiceEndpoint());
+        assertEquals(ASSUMED_ROLE, clientSettings.getAssumeRoleArn());
+    }
+
+    public void testWithoutAccessKey() {
+        expectThrows(SettingsException.class, () -> buildClientSettings(false, true, false));
+        expectThrows(SettingsException.class, () -> buildClientSettings(false, true, true));
+    }
+
+    public void testWithoutSecretKey() {
+        expectThrows(SettingsException.class, () -> buildClientSettings(true, false, false));
+        expectThrows(SettingsException.class, () -> buildClientSettings(true, false, true));
+    }
+
+    public void testWithSessionTokenButNoCredentials() {
+        expectThrows(SettingsException.class, () -> buildClientSettings(false, false, true));
+    }
+}

--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/SimpleAwsErrorHandlerTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/SimpleAwsErrorHandlerTests.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ */
+
+package org.opensearch.search.relevance.transformer.kendraintelligentranking.client;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.Request;
+import com.amazonaws.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class SimpleAwsErrorHandlerTests extends OpenSearchTestCase {
+
+    private static final int STATUS_CODE = HttpStatus.SC_PAYMENT_REQUIRED;
+    private static final String STATUS_TEXT = "Payment required";
+    private static final String SERVICE_NAME = "my-service";
+    private static final String ERROR_MESSAGE = "This is the error message";
+
+    public void testBehavior() throws Exception {
+        SimpleAwsErrorHandler errorHandler = new SimpleAwsErrorHandler();
+        assertFalse(errorHandler.needsConnectionLeftOpen());
+        Request<?> request = new DefaultRequest<>(SERVICE_NAME);
+        HttpResponse httpResponse = new HttpResponse(request, null, null);
+        httpResponse.setContent(new ByteArrayInputStream(ERROR_MESSAGE.getBytes(StandardCharsets.UTF_8)));
+        httpResponse.setStatusCode(STATUS_CODE);
+        httpResponse.setStatusText(STATUS_TEXT);
+
+        AmazonServiceException ase = errorHandler.handle(httpResponse);
+
+        assertEquals(ERROR_MESSAGE, ase.getErrorMessage());
+        assertEquals(STATUS_CODE, ase.getStatusCode());
+        assertEquals(STATUS_TEXT, ase.getErrorCode());
+        assertEquals(SERVICE_NAME, ase.getServiceName());
+    }
+}

--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/KendraIntelligentRankingExceptionTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/KendraIntelligentRankingExceptionTests.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ */
+
+package org.opensearch.search.relevance.transformer.kendraintelligentranking.model;
+
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class KendraIntelligentRankingExceptionTests extends OpenSearchTestCase {
+
+    public void testSerializationRoundtrip() throws IOException {
+        KendraIntelligentRankingException expected = new KendraIntelligentRankingException("This is an error message");
+        BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
+        expected.writeTo(bytesStreamOutput);
+
+        KendraIntelligentRankingException deserialized =
+                new KendraIntelligentRankingException(bytesStreamOutput.bytes().streamInput());
+        assertEquals(expected.getMessage(), deserialized.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/dto/DocumentTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/model/dto/DocumentTests.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *  The OpenSearch Contributors require contributions made to
+ *  this file be licensed under the Apache-2.0 license or a
+ *  compatible open source license.
+ *
+ */
+
+package org.opensearch.search.relevance.transformer.kendraintelligentranking.model.dto;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+
+public class DocumentTests extends OpenSearchTestCase {
+
+
+    public static final String JSON_DOCUMENT = "{" +
+            "\"Id\":\"docId\"," +
+            "\"GroupId\":\"groupIp\"," +
+            "\"TokenizedTitle\":[\"this\",\"is\",\"a\",\"title\"]," +
+            "\"TokenizedBody\":[\"here\",\"lies\",\"the\",\"body\"]," +
+            "\"OriginalScore\":2.71828" +
+            "}";
+    public static final Document TEST_DOCUMENT = new Document("docId",
+            "groupIp",
+            List.of("this", "is", "a", "title"),
+            List.of("here", "lies", "the", "body"),
+            2.71828f);
+
+    public void testSerialization() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonForm = objectMapper.writeValueAsString(TEST_DOCUMENT);
+        assertEquals(JSON_DOCUMENT, jsonForm);
+    }
+
+    public void testDeserialization() throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Document doc = objectMapper.readValue(JSON_DOCUMENT, Document.class);
+        assertEquals(TEST_DOCUMENT, doc);
+    }
+
+}


### PR DESCRIPTION
Added tests for Document, KendraClientSettings, and SimpleAwsErrorHandler.

Also deleted some dead code from TransformerType and
KendraIntelligentRankingException.

Works toward
https://github.com/opensearch-project/search-processor/issues/31

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
Added unit tests for Document, KendraClientSettings, and SimpleAwsErrorHandler.
 
### Issues Resolved
#31
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
