### PR TITLE
Update artifact name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ publishing {
     }
 }
 opensearchplugin {
-    name pluginName
+    name "opensearch-${pluginName}-${opensearch_version}.0"
     description pluginDescription
     classname "${projectPath}.${pathToPlugin}.${pluginClassName}"
     licenseFile rootProject.file('LICENSE')

--- a/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -5,4 +5,4 @@
         h: component
 
   - match:
-      $body: /^search-processor\n$/
+      $body: /^opensearch-search-processor-\d+.\d+.\d+.\d+\n$/


### PR DESCRIPTION
### Description
Updating artifact name to follow [OpenSearch plugin naming conventions](https://github.com/opensearch-project/opensearch-plugins/blob/main/CONVENTIONS.md#opensearch-plugins-2).

Build output:
```
➜ search-processor (main) ✔ ./gradlew build
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 7.4.2
  OS Info               : Mac OS X 12.6.3 (aarch64)
  JDK Version           : 11 (Eclipse Temurin JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-11.0.17+8/Contents/Home
  Random Testing Seed   : 32C4AADD1E0C2BC3
  In FIPS 140 mode      : false
=======================================

> Task :compileJava
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :javadoc
/Users/lnse/opensearch/search-processor/src/main/java/org/opensearch/search/relevance/configuration/ConfigurationUtils.java:30: warning: no @param for resultTransformerMap
  public static List<ResultTransformerConfiguration> getResultTransformersFromIndexConfiguration(Settings settings,
                                                     ^
/Users/lnse/opensearch/search-processor/src/main/java/org/opensearch/search/relevance/configuration/ResultTransformerConfigurationFactory.java:32: warning: no @throws for java.io.IOException
    ResultTransformerConfiguration configure(XContentParser parser) throws IOException;
                                   ^
/Users/lnse/opensearch/search-processor/src/main/java/org/opensearch/search/relevance/configuration/ResultTransformerConfigurationFactory.java:40: warning: no @throws for java.io.IOException
    ResultTransformerConfiguration configure(StreamInput streamInput) throws IOException;
                                   ^
3 warnings

> Task :compileTestJava
Note: /Users/lnse/opensearch/search-processor/src/test/java/org/opensearch/search/relevance/actionfilter/SearchActionFilterTests.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.4.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 22s
31 actionable tasks: 28 executed, 3 up-to-date
➜ search-processor (main) ✔ ls build/distributions
opensearch-search-processor-2.5.0.0-javadoc.jar     opensearch-search-processor-2.5.0.0.jar
opensearch-search-processor-2.5.0.0-sources.jar     opensearch-search-processor-2.5.0.0.zip
opensearch-search-processor-2.5.0.0-unspecified.pom search-processor-unspecified.pom
```
 
### Issues Resolved

 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
