### PR TITLE
Fix flaky test

### DIFF
--- a/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/configuration/KendraIntelligentRankingConfigurationTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/configuration/KendraIntelligentRankingConfigurationTests.java
@@ -48,7 +48,7 @@ public class KendraIntelligentRankingConfigurationTests extends OpenSearchTestCa
     }
 
     private static KendraIntelligentRankingConfiguration getKendraIntelligentRankingConfiguration() {
-        int order = randomInt(10);
+        int order = randomInt(10) + 1;
         int docLimit = randomInt( Integer.MAX_VALUE - 25) + 25;
         KendraIntelligentRankingConfiguration.KendraIntelligentRankingProperties properties =
                 new KendraIntelligentRankingConfiguration.KendraIntelligentRankingProperties(List.of("body1"),


### PR DESCRIPTION

### Description
This test was generating a random KendraIntelligentRankingConfiguation, where the "order" property would be selected from 0..10 (inclusive).

The validation fails if order is 0, causing the test to fail. Instead, we can use values between 1 and 11 (inclusive).
 
### Issues Resolved
#107 

 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
