### PR TITLE
Prepping for 2.6.0 release

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "2.5.0" ]
+        bwc_version : [ "2.6.0" ]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
 
     name: SRP Restart-Upgrade BWC Tests
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "2.5.0" ]
+        bwc_version: [ "2.6.0" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]
 
     name: SRP Rolling-Upgrade BWC Tests

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "2.5.0"
+        opensearch_version = "2.6.0"
     }
 
     repositories {
@@ -81,7 +81,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.httpcomponents:httpcore:4.4.15'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.1'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.300'

--- a/helpers/search_processing_kendra_quickstart.sh
+++ b/helpers/search_processing_kendra_quickstart.sh
@@ -20,7 +20,7 @@ if [ -z "${OPENSEARCH_DASHBOARDS_IMAGE_TAG:-}" ]; then
   OPENSEARCH_DASHBOARDS_IMAGE_TAG="opensearchproject/opensearch-dashboards:${OPENSEARCH_VERSION}"
 fi
 if [ -z "${SEARCH_PROCESSOR_PLUGIN_URL:-}" ]; then
-  SEARCH_PROCESSOR_PLUGIN_URL="https://github.com/opensearch-project/search-processor/releases/download/${OPENSEARCH_VERSION}/search-processor.zip"
+  SEARCH_PROCESSOR_PLUGIN_URL="https://github.com/opensearch-project/search-processor/releases/download/${OPENSEARCH_VERSION}/opensearch-search-processor-${OPENSEARCH_VERSION}-0.zip"
 fi
 
 function print_help() {

--- a/helpers/search_processing_kendra_quickstart.sh
+++ b/helpers/search_processing_kendra_quickstart.sh
@@ -20,7 +20,7 @@ if [ -z "${OPENSEARCH_DASHBOARDS_IMAGE_TAG:-}" ]; then
   OPENSEARCH_DASHBOARDS_IMAGE_TAG="opensearchproject/opensearch-dashboards:${OPENSEARCH_VERSION}"
 fi
 if [ -z "${SEARCH_PROCESSOR_PLUGIN_URL:-}" ]; then
-  SEARCH_PROCESSOR_PLUGIN_URL="https://github.com/opensearch-project/search-processor/releases/download/${OPENSEARCH_VERSION}/opensearch-search-processor-${OPENSEARCH_VERSION}-0.zip"
+  SEARCH_PROCESSOR_PLUGIN_URL="https://github.com/opensearch-project/search-processor/releases/download/${OPENSEARCH_VERSION}/opensearch-search-processor-${OPENSEARCH_VERSION}.0.zip"
 fi
 
 function print_help() {

--- a/helpers/search_processing_kendra_quickstart.sh
+++ b/helpers/search_processing_kendra_quickstart.sh
@@ -7,7 +7,7 @@ set -o nounset
 
 # Some useful constants
 readonly DOCKER_IMAGE_TAG="opensearch-with-ranking-plugin"
-readonly OPENSEARCH_VERSION="2.5.0"
+readonly OPENSEARCH_VERSION="2.6.0"
 
 #
 # Set default values for OpenSearch (+Dashboards) image tags and plugin URL.

--- a/release-notes/search-processor.release-notes-2.6.0.md
+++ b/release-notes/search-processor.release-notes-2.6.0.md
@@ -1,10 +1,10 @@
 ## Version 2.6.0 Release Notes
 
 ### Enhancements
-* Add more test coverage [#105](https://github.com/opensearch-project/search-processor/pull/105)
+* Add more test coverage [#100](https://github.com/opensearch-project/search-processor/pull/100)
 
 ### Infrastructure
-* Update artifact name [#109](https://github.com/opensearch-project/search-processor/pull/109)
+* Update artifact name [#106](https://github.com/opensearch-project/search-processor/pull/106)
 
 ### Maintenance
 * Bumping plugin version to `2.6.0` and `jackson-core` version to `2.14.2` [#110](https://github.com/opensearch-project/search-processor/pull/110)

--- a/release-notes/search-processor.release-notes-2.6.0.md
+++ b/release-notes/search-processor.release-notes-2.6.0.md
@@ -1,0 +1,10 @@
+## Version 2.6.0 Release Notes
+
+### Enhancements
+* Add more test coverage [#105](https://github.com/opensearch-project/search-processor/pull/105)
+
+### Infrastructure
+* Update artifact name [#109](https://github.com/opensearch-project/search-processor/pull/109)
+
+### Maintenance
+*

--- a/release-notes/search-processor.release-notes-2.6.0.md
+++ b/release-notes/search-processor.release-notes-2.6.0.md
@@ -7,4 +7,7 @@
 * Update artifact name [#109](https://github.com/opensearch-project/search-processor/pull/109)
 
 ### Maintenance
-*
+* Bumping plugin version to `2.6.0` and `jackson-core` version to `2.14.2` [#110](https://github.com/opensearch-project/search-processor/pull/110)
+
+### Documentation
+* Adding `2.6.0` release notes [#110](https://github.com/opensearch-project/search-processor/pull/110)


### PR DESCRIPTION
### Description
- Bumping plugin version to `2.6.0`
   - **Note:** The `main` branch should point to `3.0.0`. Following the release, we will fix our branches to point to the correct versions.
- Incrementing `jackson-core` to `2.14.2`
- Adding release notes
 
### Issues Resolved
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
