### PR TITLE
Switch 2.x build to 2.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ publishing {
     }
 }
 opensearchplugin {
-    name "opensearch-${pluginName}-${opensearch_version}.0"
+    name "opensearch-${pluginName}-${plugin_version}.0"
     description pluginDescription
     classname "${projectPath}.${pathToPlugin}.${pluginClassName}"
     licenseFile rootProject.file('LICENSE')
@@ -53,7 +53,13 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "2.6.0"
+        plugin_version = "2.7.0"
+        snapshot = true // Set to false on release
+        if (snapshot) {
+            opensearch_version = plugin_version + "-SNAPSHOT"
+        } else {
+            opensearch_version = plugin_version
+        }
     }
 
     repositories {


### PR DESCRIPTION
Also, backported the plugin version logic from main branch.

### Description
This changes the plugin version to 2.7.0 on the 2.x branch, following the semver best practice where the 2.x branch points to the **next** release in the 2.x series.

Also, it backports the versioning logic from `main`, where we have separate variables for the plugin version and whether to build against OpenSearch snapshot releases.

### Issues Resolved
#118 
 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] ~~New functionality has been documented.~~
  - [ ] ~~New functionality has javadoc added~~
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
