### PR TITLE
updating build.gradle to use snapshot by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,12 +53,11 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        plugin_version = "3.0.0"
-        snapshot = true // Set to false on release
-        if (snapshot) {
-            opensearch_version = plugin_version + "-SNAPSHOT"
-        } else {
-            opensearch_version = plugin_version
+        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0")
+        plugin_version = opensearch_version
+        if (isSnapshot) {
+            opensearch_version += "-SNAPSHOT"
         }
     }
 


### PR DESCRIPTION
### Description
Updates `build.gradle` to follow other plugin patterns (in particular, using `System.getProperty` for using `SNAPSHOT` dependencies.
 
### Issues Resolved

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
