### PR TITLE
adding Sean Li - sejli as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the MAINTAINERS.md file in the root of this repo
-*   @msfroh @macohen @noCharger @mingshl
+*   @msfroh @macohen @noCharger @mingshl @sejli

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Mark Cohen      | [macohen](https://github.com/macohen)     | Amazon      |
 | Louis Chu       | [noCharger](https://github.com/noCharger) | Amazon      |
 | Mingshi Liu     | [mingshl](https://github.com/mingshl)     | Amazon      |
+| Sean Li     | [sejli](https://github.com/sejli)     | Amazon      |


### PR DESCRIPTION
### Description
Adding Sean Li as a maintainer.
 
### Issues Resolved
https://github.com/opensearch-project/search-processor/issues/127
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
