### PR TITLE
[Backport 2.x] Prepping for 2.7.0 release

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version : [ "2.6.0" ]
+        bwc_version : [ "2.7.0" ]
         opensearch_version : [ "3.0.0-SNAPSHOT" ]
 
     name: SRP Restart-Upgrade BWC Tests
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        bwc_version: [ "2.6.0" ]
+        bwc_version: [ "2.7.0" ]
         opensearch_version: [ "3.0.0-SNAPSHOT" ]
 
     name: SRP Rolling-Upgrade BWC Tests

--- a/helpers/search_processing_kendra_quickstart.sh
+++ b/helpers/search_processing_kendra_quickstart.sh
@@ -7,7 +7,7 @@ set -o nounset
 
 # Some useful constants
 readonly DOCKER_IMAGE_TAG="opensearch-with-ranking-plugin"
-readonly OPENSEARCH_VERSION="2.6.0"
+readonly OPENSEARCH_VERSION="2.7.0"
 
 #
 # Set default values for OpenSearch (+Dashboards) image tags and plugin URL.

--- a/release-notes/search-processor.release-notes-2.7.0.md
+++ b/release-notes/search-processor.release-notes-2.7.0.md
@@ -1,0 +1,11 @@
+## Version 2.7.0 Release Notes
+
+### Enhancements
+* Improve test coverage [#99](https://github.com/opensearch-project/search-processor/pull/99)
+
+### Infrastructure
+* Updating build.gradle to use snapshot by default [#124](https://github.com/opensearch-project/search-processor/pull/124)
+* Accommodate changes to XContent classes [#125](https://github.com/opensearch-project/search-processor/pull/125)
+
+### Documentation
+* Prepping for 2.7.0 release [#130](https://github.com/opensearch-project/search-processor/pull/130)


### PR DESCRIPTION
Prepping for 2.7.0 release

Backport failed for #130, running commands manually
(cherry picked from commit 095d367ced1c316d7d355ea9016bd166508e5a6e)

### Description
#130 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
