### PR TITLE
Scoring logic for reranking open search hits based on personalize campaign response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.httpcomponents:httpcore:4.4.15'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.0'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.300'

--- a/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/ranker/impl/AmazonPersonalizeRankerImplTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/ranker/impl/AmazonPersonalizeRankerImplTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.search.relevance.transformer.personalizeintelligentranking.ranker.impl;
 
 import org.mockito.Mockito;
+import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.relevance.transformer.personalizeintelligentranking.client.PersonalizeClient;
 import org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.PersonalizeIntelligentRankerConfiguration;
@@ -18,9 +19,14 @@ import org.opensearch.search.relevance.transformer.personalizeintelligentranking
 import org.opensearch.search.relevance.transformer.personalizeintelligentranking.utils.SearchTestUtil;
 import org.opensearch.test.OpenSearchTestCase;
 
+
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
 
@@ -32,6 +38,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
     private String itemIdField = "ITEM_ID";
     private String region = "us-west-2";
     private double weight = 0.25;
+    private int numOfHits = 10;
 
     public void testReRank() throws IOException {
         PersonalizeIntelligentRankerConfiguration rankerConfig =
@@ -42,7 +49,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setUserId("28");
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
@@ -57,7 +64,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setUserId("28");
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
@@ -74,7 +81,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setUserId("28");
         requestParameters.setContext(context);
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
@@ -91,7 +98,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setUserId("28");
         requestParameters.setContext(context);
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
@@ -107,7 +114,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         context.put("contextKey", "contextValue");
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setContext(context);
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
@@ -122,7 +129,7 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setUserId("28");
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
@@ -136,8 +143,275 @@ public class AmazonPersonalizeRankerImplTests extends OpenSearchTestCase {
         AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
         PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
         requestParameters.setUserId("28");
-        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(10);
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
         SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
         assertEquals(responseHits.getHits().length, transformedHits.getHits().length);
     }
+
+
+    public void testReRankWithWeightAsZero() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, itemIdField, region, 0);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResult(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getSourceAsMap().get(itemIdfield) != null)
+                .map(h -> h.getSourceAsMap().get(itemIdfield).toString())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZero(numOfHits);
+
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+
+    public void testReRankWithWeightAsOne() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, itemIdField, region, 1);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResult(numOfHits));
+
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getSourceAsMap().get(itemIdfield) != null)
+                .map(h -> h.getSourceAsMap().get(itemIdfield).toString())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsOne(numOfHits);
+
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+    public void testReRankWithWeightAsNietherZeroOrOne() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, itemIdField, region, weight);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResult(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getSourceAsMap().get(itemIdfield) != null)
+                .map(h -> h.getSourceAsMap().get(itemIdfield).toString())
+                .collect(Collectors.toList());
+
+        ArrayList<String> rerankedDocumentIdsWhenWeightIsOne = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsOne(numOfHits);
+        ArrayList<String> rerankedDocumentIdsWhenWeightIsZero = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZero(numOfHits);
+
+        assertNotEquals(rerankedDocumentIdsWhenWeightIsOne, rerankedDocumentIds);
+        assertNotEquals(rerankedDocumentIdsWhenWeightIsZero, rerankedDocumentIds);
+    }
+
+    public void testReRankWithWeightAsGreaterThanOne() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, itemIdField, region, 2);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResult(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getSourceAsMap().get(itemIdfield) != null)
+                .map(h -> h.getSourceAsMap().get(itemIdfield).toString())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZero(numOfHits);
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+    public void testReRankWithWeightAsLessThanZero() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, itemIdField, region, -1);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResult(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getSourceAsMap().get(itemIdfield) != null)
+                .map(h -> h.getSourceAsMap().get(itemIdfield).toString())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZero(numOfHits);
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+
+    public void testReRankWithWeightAsZeroWithNullItemIdField() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, "", region, 0);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResultWhenItemIdConfigIsEmpty(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getId() != null)
+                .map(h -> h.getId())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZeroWithNullItemIdField(numOfHits);
+
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+
+    public void testReRankWithWeightAsOneWithNullItemIdField() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, "", region, 1);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResultWhenItemIdConfigIsEmpty(numOfHits));
+
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getId() != null)
+                .map(h -> h.getId())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsOneWithNullItemIdField(numOfHits);
+
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+    public void testReRankWithWeightAsNietherZeroOrOneWithNullItemIdField() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, "", region, weight);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResultWhenItemIdConfigIsEmpty(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getId() != null)
+                .map(h -> h.getId())
+                .collect(Collectors.toList());
+
+        ArrayList<String> rerankedDocumentIdsWhenWeightIsOne = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsOneWithNullItemIdField(numOfHits);
+        ArrayList<String> rerankedDocumentIdsWhenWeightIsZero = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZeroWithNullItemIdField(numOfHits);
+
+        assertNotEquals(rerankedDocumentIdsWhenWeightIsOne, rerankedDocumentIds);
+        assertNotEquals(rerankedDocumentIdsWhenWeightIsZero, rerankedDocumentIds);
+    }
+
+    public void testReRankWithWeightAsGreaterThanOneWithNullItemIdField() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, "", region, 2);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResultWhenItemIdConfigIsEmpty(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getId() != null)
+                .map(h -> h.getId())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZeroWithNullItemIdField(numOfHits);
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
+    public void testReRankWithWeightAsLessThanZeroWithNullItemIdField() throws IOException {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, recipe, "", region, -1);
+        PersonalizeClient client = Mockito.mock(PersonalizeClient.class);
+        Mockito.when(client.getPersonalizedRanking(any())).thenReturn(PersonalizeRuntimeTestUtil.buildGetPersonalizedRankingResultWhenItemIdConfigIsEmpty(numOfHits));
+
+        AmazonPersonalizedRankerImpl ranker = new AmazonPersonalizedRankerImpl(rankerConfig, client);
+        PersonalizeRequestParameters requestParameters = new PersonalizeRequestParameters();
+        requestParameters.setUserId("28");
+        SearchHits responseHits = SearchTestUtil.getSampleSearchHitsForPersonalize(numOfHits);
+        SearchHits transformedHits = ranker.rerank(responseHits, requestParameters);
+
+        List<SearchHit> originalHits = Arrays.asList(transformedHits.getHits());
+        String itemIdfield = rankerConfig.getItemIdField();
+        List<String> rerankedDocumentIds;
+
+        rerankedDocumentIds = originalHits.stream()
+                .filter(h -> h.getId() != null)
+                .map(h -> h.getId())
+                .collect(Collectors.toList());
+
+        ArrayList<String> expectedRankedDocumentIds = PersonalizeRuntimeTestUtil.expectedRankedItemIdsWhenWeightIsZeroWithNullItemIdField(numOfHits);
+        assertEquals(expectedRankedDocumentIds, rerankedDocumentIds);
+    }
+
 }

--- a/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/PersonalizeRuntimeTestUtil.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/PersonalizeRuntimeTestUtil.java
@@ -31,4 +31,66 @@ public class PersonalizeRuntimeTestUtil {
                 .withRecommendationId("sampleRecommendationId");
         return result;
     }
+
+    public static GetPersonalizedRankingResult buildGetPersonalizedRankingResult(int numOfHits) {
+        List<PredictedItem> predictedItems = new ArrayList<>();
+        for(int i = numOfHits; i >= 1; i--){
+            PredictedItem predictedItem = new PredictedItem().
+                    withScore((double) i/10).
+                    withItemId(String.valueOf(i-1));
+            predictedItems.add(predictedItem);
+        }
+        GetPersonalizedRankingResult result = new GetPersonalizedRankingResult()
+                .withPersonalizedRanking(predictedItems)
+                .withRecommendationId("sampleRecommendationId");
+        return result;
+    }
+
+
+    public static GetPersonalizedRankingResult buildGetPersonalizedRankingResultWhenItemIdConfigIsEmpty(int numOfHits) {
+        List<PredictedItem> predictedItems = new ArrayList<>();
+        for(int i = numOfHits; i >= 1; i--){
+            PredictedItem predictedItem = new PredictedItem().
+                    withScore((double) i/10).
+                    withItemId("doc"+ (i - 1));
+            predictedItems.add(predictedItem);
+        }
+
+        GetPersonalizedRankingResult result = new GetPersonalizedRankingResult()
+                .withPersonalizedRanking(predictedItems)
+                .withRecommendationId("sampleRecommendationId");
+        return result;
+    }
+
+    public static ArrayList<String> expectedRankedItemIdsWhenWeightIsOne(int numOfHits){
+        ArrayList<String> expectedRankedItemIds = new ArrayList<>();
+        for(int i = numOfHits; i >= 1; i--){
+            expectedRankedItemIds.add(String.valueOf(i-1));
+        }
+        return expectedRankedItemIds;
+    }
+
+    public static ArrayList<String> expectedRankedItemIdsWhenWeightIsZero(int numOfHits){
+        ArrayList<String> expectedRankedItemIds = new ArrayList<>();
+        for(int i = 0; i <numOfHits; i++){
+            expectedRankedItemIds.add(String.valueOf(i));
+        }
+        return expectedRankedItemIds;
+    }
+
+    public static ArrayList<String> expectedRankedItemIdsWhenWeightIsOneWithNullItemIdField(int numOfHits){
+        ArrayList<String> expectedRankedItemIds = new ArrayList<>();
+        for(int i = numOfHits; i >= 1; i--){
+            expectedRankedItemIds.add("doc" + (i - 1));
+        }
+        return expectedRankedItemIds;
+    }
+
+    public static ArrayList<String> expectedRankedItemIdsWhenWeightIsZeroWithNullItemIdField(int numOfHits){
+        ArrayList<String> expectedRankedItemIds = new ArrayList<>();
+        for(int i = 0; i <numOfHits; i++){
+            expectedRankedItemIds.add("doc" + i);
+        }
+        return expectedRankedItemIds;
+    }
 }

--- a/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/SearchTestUtil.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/SearchTestUtil.java
@@ -29,6 +29,7 @@ public class SearchTestUtil {
                     .field("title", "This is the title for document " + i)
                     .endObject();
             hitsArray[i] = new SearchHit(i, "doc" + i, Map.of(), Map.of());
+            hitsArray[i].score((float) (numHits-i)/10);
             hitsArray[i].sourceRef(BytesReference.bytes(sourceContent));
         }
         SearchHits searchHits = new SearchHits(hitsArray, new TotalHits(numHits, TotalHits.Relation.EQUAL_TO), 1.0f);


### PR DESCRIPTION
Scoring logic for reranking open search hits based on personalize campaign response

### Description
This change implements a scoring logic based on reciprocal logarithm rank combination to rerank open search hits based on response from personalize campaign

### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
