### PR TITLE
Bump Httpclient to 4.5.14 and Httpcore to 4.4.16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,8 @@ repositories {
 dependencies {
     implementation 'com.ibm.icu:icu4j:57.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.apache.httpcomponents:httpcore:4.4.15'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.15.2'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.15.0'


### PR DESCRIPTION
### Description
Bump Httpclient to 4.5.14 and Httpcore to 4.4.16

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
