### PR TITLE
[Backport 2.8] Fetch index settings asynchronously (#135)

### DIFF
--- a/src/main/java/org/opensearch/search/relevance/client/OpenSearchClient.java
+++ b/src/main/java/org/opensearch/search/relevance/client/OpenSearchClient.java
@@ -7,6 +7,7 @@
  */
 package org.opensearch.search.relevance.client;
 
+import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsAction;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -20,13 +21,13 @@ public class OpenSearchClient {
     this.client = client;
   }
 
-  public Settings getIndexSettings(String indexName, String[] settingNames) {
+  public void getIndexSettings(String indexName, String[] settingNames, ActionListener<Settings> settingsListener) {
     GetSettingsRequest getSettingsRequest = new GetSettingsRequest()
         .indices(indexName);
     if (settingNames != null && settingNames.length > 0) {
       getSettingsRequest.names(settingNames);
     }
-    GetSettingsResponse getSettingsResponse = client.execute(GetSettingsAction.INSTANCE, getSettingsRequest).actionGet();
-    return getSettingsResponse.getIndexToSettings().get(indexName);
+    ActionListener<GetSettingsResponse> responseListener = ActionListener.map(settingsListener, r -> r.getIndexToSettings().get(indexName));
+    client.execute(GetSettingsAction.INSTANCE, getSettingsRequest, responseListener);
   }
 }

--- a/src/main/java/org/opensearch/search/relevance/configuration/ConfigurationUtils.java
+++ b/src/main/java/org/opensearch/search/relevance/configuration/ConfigurationUtils.java
@@ -7,6 +7,7 @@
  */
 package org.opensearch.search.relevance.configuration;
 
+import org.opensearch.action.ActionListener;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.search.SearchExtBuilder;
@@ -22,74 +23,77 @@ import static org.opensearch.search.relevance.configuration.Constants.RESULT_TRA
 
 public class ConfigurationUtils {
 
-  /**
-  * Get result transformer configurations from Search Request
-  * @param settings all index settings configured for this plugin
-  * @return ordered and validated list of result transformers, empty list if not specified
-  */
-  public static List<ResultTransformerConfiguration> getResultTransformersFromIndexConfiguration(Settings settings,
-                                                                                                 Map<String, ResultTransformer> resultTransformerMap) {
-    List<ResultTransformerConfiguration> indexLevelConfigs = new ArrayList<>();
+    /**
+     * Get result transformer configurations from Search Request
+     *
+     * @param settings all index settings configured for this plugin
+     * @return ordered and validated list of result transformers, empty list if not specified
+     */
+    public static List<ResultTransformerConfiguration> getResultTransformersFromIndexConfiguration(Settings settings,
+                                                                                                   Map<String, ResultTransformer> resultTransformerMap) {
+        List<ResultTransformerConfiguration> indexLevelConfigs = new ArrayList<>();
 
-    if (settings != null) {
-      if (settings.getGroups(RESULT_TRANSFORMER_SETTING_PREFIX) != null) {
-        for (Map.Entry<String, Settings> transformerSettings : settings.getGroups(RESULT_TRANSFORMER_SETTING_PREFIX).entrySet()) {
-          if (resultTransformerMap.containsKey(transformerSettings.getKey())) {
-            ResultTransformer transformer = resultTransformerMap.get(transformerSettings.getKey());
-            indexLevelConfigs.add(transformer.getConfigurationFactory().configure(transformerSettings.getValue()));
-          }
+        if (settings != null) {
+            if (settings.getGroups(RESULT_TRANSFORMER_SETTING_PREFIX) != null) {
+                for (Map.Entry<String, Settings> transformerSettings : settings.getGroups(RESULT_TRANSFORMER_SETTING_PREFIX).entrySet()) {
+                    if (resultTransformerMap.containsKey(transformerSettings.getKey())) {
+                        ResultTransformer transformer = resultTransformerMap.get(transformerSettings.getKey());
+                        indexLevelConfigs.add(transformer.getConfigurationFactory().configure(transformerSettings.getValue()));
+                    }
+                }
+            }
         }
-      }
+
+        return reorderAndValidateConfigs(indexLevelConfigs);
     }
 
-    return reorderAndValidateConfigs(indexLevelConfigs);
-  }
+    /**
+     * Get result transformer configurations from Search Request
+     *
+     * @param searchRequest input request
+     * @return ordered and validated list of result transformers, empty list if not specified
+     */
+    public static List<ResultTransformerConfiguration> getResultTransformersFromRequestConfiguration(
+            final SearchRequest searchRequest) {
 
-  /**
-   * Get result transformer configurations from Search Request
-   * @param searchRequest input request
-   * @return ordered and validated list of result transformers, empty list if not specified
-   */
-  public static List<ResultTransformerConfiguration> getResultTransformersFromRequestConfiguration(
-      final SearchRequest searchRequest) {
+        // Fetch result transformers specified in request
+        SearchConfigurationExtBuilder requestLevelSearchConfiguration = null;
+        if (searchRequest.source() != null && searchRequest.source().ext() != null && !searchRequest.source().ext().isEmpty()) {
+            // Filter ext builders by name
+            List<SearchExtBuilder> extBuilders = searchRequest.source().ext().stream()
+                    .filter(searchExtBuilder -> SearchConfigurationExtBuilder.NAME.equals(searchExtBuilder.getWriteableName()))
+                    .collect(Collectors.toList());
+            if (!extBuilders.isEmpty()) {
+                requestLevelSearchConfiguration = (SearchConfigurationExtBuilder) extBuilders.get(0);
+            }
+        }
 
-    // Fetch result transformers specified in request
-    SearchConfigurationExtBuilder requestLevelSearchConfiguration = null;
-    if (searchRequest.source() != null && searchRequest.source().ext() != null && !searchRequest.source().ext().isEmpty()) {
-      // Filter ext builders by name
-      List<SearchExtBuilder> extBuilders = searchRequest.source().ext().stream()
-          .filter(searchExtBuilder -> SearchConfigurationExtBuilder.NAME.equals(searchExtBuilder.getWriteableName()))
-          .collect(Collectors.toList());
-      if (!extBuilders.isEmpty()) {
-        requestLevelSearchConfiguration = (SearchConfigurationExtBuilder) extBuilders.get(0);
-      }
+        List<ResultTransformerConfiguration> requestLevelConfigs = new ArrayList<>();
+        if (requestLevelSearchConfiguration != null) {
+            requestLevelConfigs = reorderAndValidateConfigs(requestLevelSearchConfiguration.getResultTransformers());
+        }
+        return requestLevelConfigs;
     }
 
-    List<ResultTransformerConfiguration> requestLevelConfigs = new ArrayList<>();
-    if (requestLevelSearchConfiguration != null) {
-      requestLevelConfigs = reorderAndValidateConfigs(requestLevelSearchConfiguration.getResultTransformers());
+    /**
+     * Sort configurations in ascending order of invocation, and validate
+     *
+     * @param configs list of result transformer configurations
+     * @return ordered and validated list of result transformers
+     */
+    public static List<ResultTransformerConfiguration> reorderAndValidateConfigs(
+            final List<ResultTransformerConfiguration> configs) throws IllegalArgumentException {
+
+        // Sort
+        configs.sort(Comparator.comparingInt(ResultTransformerConfiguration::getOrder));
+
+        for (int i = 0; i < configs.size(); ++i) {
+            if (configs.get(i).getOrder() != (i + 1)) {
+                throw new IllegalArgumentException("Expected order [" + (i + 1) + "] for transformer [" +
+                        configs.get(i).getTransformerName() + "], but found [" + configs.get(i).getOrder() + "]");
+            }
+        }
+
+        return configs;
     }
-    return requestLevelConfigs;
-  }
-
-  /**
-   * Sort configurations in ascending order of invocation, and validate
-   * @param configs list of result transformer configurations
-   * @return ordered and validated list of result transformers
-   */
-  public static List<ResultTransformerConfiguration> reorderAndValidateConfigs(
-      final List<ResultTransformerConfiguration> configs) throws IllegalArgumentException {
-
-    // Sort
-    configs.sort(Comparator.comparingInt(ResultTransformerConfiguration::getOrder));
-
-    for (int i = 0; i < configs.size(); ++i) {
-      if (configs.get(i).getOrder() != (i + 1)) {
-        throw new IllegalArgumentException("Expected order [" + (i + 1) + "] for transformer [" +
-            configs.get(i).getTransformerName() + "], but found [" + configs.get(i).getOrder() + "]");
-      }
-    }
-
-    return configs;
-  }
 }

--- a/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/10_basic.yml
@@ -6,3 +6,12 @@
 
   - match:
       $body: /^opensearch-search-processor-\d+.\d+.\d+.\d+\n$/
+
+  - do:
+      indices.create:
+        index:  test
+
+  - do:
+      search:
+        index: test
+        body: { }


### PR DESCRIPTION
In some cases, like using ./gradlew run, I've run into issues where OpenSearch crashes, complaining that we're making a blocking call on a listener thread, because we fetch index settings to see if a result transformer has been configured for the current index.

I'm kind of surprised that we haven't run into this in production use-cases, but it may just be because assertions are not enabled in production. Regardless, blocking calls on listener threads are a bad idea, since that's how you run out of listener threads.

This change makes the index settings call asynchronous and chains the remaining logic off of that.

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
