### PR TITLE
Pass environment setting to personalized setting while cluster is up

### DIFF
--- a/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/client/PersonalizeClientSettings.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/client/PersonalizeClientSettings.java
@@ -18,6 +18,9 @@ import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.settings.SettingsException;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 /**
  * Container for personalize client settings such as AWS credentials
  */
@@ -44,6 +47,14 @@ public final class PersonalizeClientSettings {
 
     protected PersonalizeClientSettings(AWSCredentials credentials) {
         this.credentials = credentials;
+    }
+
+    public static Collection<? extends Setting<?>> getAllSettings() {
+        return Arrays.asList(
+                ACCESS_KEY_SETTING,
+                SECRET_KEY_SETTING,
+                SESSION_TOKEN_SETTING
+        );
     }
 
     public AWSCredentials getCredentials() {

--- a/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/client/PersonalizeClientSettingsTests.java
+++ b/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/client/PersonalizeClientSettingsTests.java
@@ -9,11 +9,17 @@ package org.opensearch.search.relevance.transformer.personalizeintelligentrankin
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSSessionCredentials;
+import org.opensearch.common.settings.SecureSetting;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.SettingsException;
+import org.opensearch.core.common.settings.SecureString;
 import org.opensearch.search.relevance.transformer.personalizeintelligentranking.utils.PersonalizeClientSettingsTestUtil;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.utils.PersonalizeClientSettingsTestUtil.ACCESS_KEY;
 import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.utils.PersonalizeClientSettingsTestUtil.SECRET_KEY;
@@ -27,6 +33,17 @@ public class PersonalizeClientSettingsTests extends OpenSearchTestCase {
         assertEquals(ACCESS_KEY, credentials.getAWSAccessKeyId());
         assertEquals(SECRET_KEY, credentials.getAWSSecretKey());
         assertFalse(credentials instanceof AWSSessionCredentials);
+    }
+
+    public void testWithGetAllSetting() throws IOException {
+        PersonalizeClientSettings clientSettings = PersonalizeClientSettingsTestUtil.buildClientSettings(true, true, true);
+        assertEquals(clientSettings.getAllSettings().size(), 3);
+        Setting<SecureString> ACCESS_KEY_SETTING = SecureSetting.secureString("personalized_search_ranking.aws.access_key", null);
+        Setting<SecureString> SECRET_KEY_SETTING = SecureSetting.secureString("personalized_search_ranking.aws.secret_key", null);
+        Setting<SecureString> SESSION_TOKEN_SETTING = SecureSetting.secureString("personalized_search_ranking.aws.session_token", null);
+        assertEquals(ACCESS_KEY_SETTING, clientSettings.getAllSettings().toArray()[0]);
+        assertEquals(SECRET_KEY_SETTING, clientSettings.getAllSettings().toArray()[1]);
+        assertEquals(SESSION_TOKEN_SETTING, clientSettings.getAllSettings().toArray()[2]);
     }
 
     public void testWithSessionCredentials() throws IOException {


### PR DESCRIPTION
### Description
When the cluster runs on opensearch, it reads the credentials from the keystore and will pass setting to the plugins, and it will be close after the cluster is fully running. 

Raise this PR to pass environment setting to personalized setting while cluster is up

 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
