### PR TITLE
Fix AccessControlException while creating client configuration for Personalize client

### DIFF
--- a/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/client/PersonalizeClient.java
+++ b/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/client/PersonalizeClient.java
@@ -33,8 +33,9 @@ public class PersonalizeClient implements Closeable {
      * @param awsRegion AWS region where Amazon Personalize campaign is hosted
      */
     public PersonalizeClient(AWSCredentialsProvider credentialsProvider, String awsRegion) {
-        ClientConfiguration clientConfiguration = new ClientConfiguration()
-                .withUserAgentPrefix(USER_AGENT_PREFIX);
+        ClientConfiguration clientConfiguration = AccessController.doPrivileged(
+                (PrivilegedAction<ClientConfiguration>) () -> new ClientConfiguration()
+                .withUserAgentPrefix(USER_AGENT_PREFIX));
         personalizeRuntime = AccessController.doPrivileged(
                 (PrivilegedAction<AmazonPersonalizeRuntime>) () -> AmazonPersonalizeRuntimeClientBuilder.standard()
                         .withCredentials(credentialsProvider)


### PR DESCRIPTION
### Description:
This change included fix for ``AccessControlException`` error while initializing client configuration for AWS Personalize client. We see below exception while intializing client configuration for Personalize client only when using credentials from opensearch keystore. 
**Exception message:**
```
[2023-07-17T13:26:24,096][ERROR][o.o.b.OpenSearchUncaughtExceptionHandler] [88665a0bfb08.ant.amazon.com] fatal error in thread [opensearch[88665a0bfb08.ant.amazon.com][management][T#2]], exiting
java.lang.ExceptionInInitializerError: null
	at com.amazonaws.util.VersionInfoUtils.userAgent(VersionInfoUtils.java:142) ~[?:?]
	at com.amazonaws.util.VersionInfoUtils.initializeUserAgent(VersionInfoUtils.java:137) ~[?:?]
	at com.amazonaws.util.VersionInfoUtils.getUserAgent(VersionInfoUtils.java:100) ~[?:?]
	at com.amazonaws.ClientConfiguration.<clinit>(ClientConfiguration.java:80) ~[?:?]

....
Caused by: java.security.AccessControlException: access denied ("java.lang.RuntimePermission" "getClassLoader")
	at java.security.AccessControlContext.checkPermission(AccessControlContext.java:472) ~[?:?]
	at java.security.AccessController.checkPermission(AccessController.java:897) ~[?:?]
	at java.lang.SecurityManager.checkPermission(SecurityManager.java:322) ~[?:?]
....

```

### Check List
- [X] New functionality includes testing.
- [X] All tests pass
- [X] New functionality has been documented.
- [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).