### PR TITLE
Remove dependency on commons-lang3

### DIFF
--- a/amazon-kendra-intelligent-ranking/build.gradle
+++ b/amazon-kendra-intelligent-ranking/build.gradle
@@ -60,7 +60,6 @@ repositories {
 
 dependencies {
     implementation 'com.ibm.icu:icu4j:57.2'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'

--- a/amazon-kendra-intelligent-ranking/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraHttpClient.java
+++ b/amazon-kendra-intelligent-ranking/src/main/java/org/opensearch/search/relevance/transformer/kendraintelligentranking/client/KendraHttpClient.java
@@ -30,13 +30,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import org.apache.commons.lang3.StringUtils;
+import org.opensearch.core.common.Strings;
 import org.opensearch.search.relevance.transformer.kendraintelligentranking.model.dto.RescoreRequest;
 import org.opensearch.search.relevance.transformer.kendraintelligentranking.model.dto.RescoreResult;
 
@@ -132,11 +131,11 @@ public class KendraHttpClient implements Closeable {
   }
 
   public boolean isValid() {
-    return StringUtils.isNotEmpty(serviceEndpoint) && StringUtils.isNotEmpty(executionPlanId);
+    return !Strings.isNullOrEmpty(serviceEndpoint) && !Strings.isNullOrEmpty(executionPlanId);
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() {
     if (amazonHttpClient != null) {
       amazonHttpClient.shutdown();
     }


### PR DESCRIPTION
Was only used to check for strings being null or empty. We don't need a whole extra library dependency for that (especially since OpenSearch already provides a utility method for that).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
