### PR TITLE
Move versioning logic to the root project

### DIFF
--- a/amazon-kendra-intelligent-ranking/build.gradle
+++ b/amazon-kendra-intelligent-ranking/build.gradle
@@ -30,15 +30,6 @@ loggerUsageCheck.enabled = false
 validateNebulaPom.enabled = false
 
 buildscript {
-    ext {
-        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0")
-        plugin_version = opensearch_version
-        if (isSnapshot) {
-            opensearch_version += "-SNAPSHOT"
-        }
-    }
-
     repositories {
         mavenLocal()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }

--- a/amazon-personalize-ranking/build.gradle
+++ b/amazon-personalize-ranking/build.gradle
@@ -31,15 +31,6 @@ loggerUsageCheck.enabled = false
 validateNebulaPom.enabled = false
 
 buildscript {
-    ext {
-        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0")
-        plugin_version = opensearch_version
-        if (isSnapshot) {
-            opensearch_version += "-SNAPSHOT"
-        }
-    }
-
     repositories {
         mavenLocal()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,8 @@
+ext {
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+    opensearch_version = System.getProperty("opensearch.version", "3.0.0")
+    plugin_version = opensearch_version
+    if (isSnapshot) {
+        opensearch_version += "-SNAPSHOT"
+    }
+}


### PR DESCRIPTION
Instead of computing the OpenSearch + plugin version in the subprojects, we can do it in the root project and propagate the `ext` variables.

### Check List
- ~~[ ] New functionality includes testing.~~
  - ~~[ ] All tests pass~~
- ~~[ ] New functionality has been documented.~~
  - ~~[ ] New functionality has javadoc added~~
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
