### PR TITLE
Bumping version to 2.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    opensearch_version = System.getProperty("opensearch.version", "2.12.0")
+    opensearch_version = System.getProperty("opensearch.version", "2.13.0")
     plugin_version = opensearch_version
     if (isSnapshot) {
         opensearch_version += "-SNAPSHOT"


### PR DESCRIPTION
### Description
Bumps `search-processor` version to `2.13`.

Will merge #222 afterwards to fix build.
 
### Issues Resolved
N/A.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
