### PR TITLE
Upgrade jackson-core to 2.17.1

### DIFF
--- a/amazon-kendra-intelligent-ranking/build.gradle
+++ b/amazon-kendra-intelligent-ranking/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.0'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.300'

--- a/amazon-personalize-ranking/build.gradle
+++ b/amazon-personalize-ranking/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.apache.httpcomponents:httpcore:4.4.16'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.0'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.16.0'
     implementation 'com.amazonaws:aws-java-sdk-sts:1.12.300'
     implementation 'com.amazonaws:aws-java-sdk-core:1.12.300'


### PR DESCRIPTION
### Description
Upgrades jackson-core dependency to 2.17.1 to keep it sync with OpenSearch core.
 
### Issues Resolved
Fixes build
 
### Check List
- [ ] ~New functionality includes testing.~
  - [ ] ~All tests pass~
- [ ] ~New functionality has been documented.~
  - [ ] ~New functionality has javadoc added~
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
