### PR TITLE
Feat intelligent ranking

### DIFF
--- a/amazon-personalize-ranking/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/configuration/Constants.java
+++ b/amazon-personalize-ranking/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/configuration/Constants.java
@@ -13,4 +13,5 @@ package org.opensearch.search.relevance.transformer.personalizeintelligentrankin
  */
 public class Constants {
     public static final String AMAZON_PERSONALIZED_RANKING_RECIPE_NAME = "aws-personalized-ranking";
+    public static final String AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME = "aws-personalized-ranking-v2";
 }

--- a/amazon-personalize-ranking/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/reranker/PersonalizedRankerFactory.java
+++ b/amazon-personalize-ranking/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/reranker/PersonalizedRankerFactory.java
@@ -14,6 +14,7 @@ import org.opensearch.search.relevance.transformer.personalizeintelligentranking
 import org.opensearch.search.relevance.transformer.personalizeintelligentranking.reranker.impl.AmazonPersonalizedRankerImpl;
 
 import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.Constants.AMAZON_PERSONALIZED_RANKING_RECIPE_NAME;
+import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.Constants.AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME;
 
 /**
  * Factory for creating Personalize ranker instance based on Personalize ranker configuration
@@ -29,7 +30,9 @@ public class PersonalizedRankerFactory {
      */
     public PersonalizedRanker getPersonalizedRanker(PersonalizeIntelligentRankerConfiguration config, PersonalizeClient client){
         PersonalizedRanker ranker = null;
-        if (config.getRecipe().equals(AMAZON_PERSONALIZED_RANKING_RECIPE_NAME)) {
+        String recipeInConfig = config.getRecipe();
+        if (recipeInConfig.equals(AMAZON_PERSONALIZED_RANKING_RECIPE_NAME)
+                || recipeInConfig.equals(AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME)) {
             ranker = new AmazonPersonalizedRankerImpl(config, client);
         } else {
             logger.error("Personalize recipe provided in configuration is not supported for re ranking search results");

--- a/amazon-personalize-ranking/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/ValidationUtil.java
+++ b/amazon-personalize-ranking/src/main/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/ValidationUtil.java
@@ -15,9 +15,13 @@ import java.util.Set;
 import java.util.HashSet;
 
 import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.Constants.AMAZON_PERSONALIZED_RANKING_RECIPE_NAME;
+import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.Constants.AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME;
 
 public class ValidationUtil {
-    private static Set<String> SUPPORTED_PERSONALIZE_RECIPES = new HashSet<>(Arrays.asList(AMAZON_PERSONALIZED_RANKING_RECIPE_NAME));
+    private static Set<String> SUPPORTED_PERSONALIZE_RECIPES = new HashSet<>(Arrays.asList(
+            AMAZON_PERSONALIZED_RANKING_RECIPE_NAME,
+            AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME
+    ));
 
     /**
      * Validate Personalize configuration for calling Personalize service.

--- a/amazon-personalize-ranking/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/ValidationUtilTests.java
+++ b/amazon-personalize-ranking/src/test/java/org/opensearch/search/relevance/transformer/personalizeintelligentranking/utils/ValidationUtilTests.java
@@ -13,6 +13,7 @@ import org.opensearch.search.relevance.transformer.personalizeintelligentranking
 import org.opensearch.test.OpenSearchTestCase;
 
 import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.Constants.AMAZON_PERSONALIZED_RANKING_RECIPE_NAME;
+import static org.opensearch.search.relevance.transformer.personalizeintelligentranking.configuration.Constants.AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME;
 
 public class ValidationUtilTests extends OpenSearchTestCase {
 
@@ -27,6 +28,12 @@ public class ValidationUtilTests extends OpenSearchTestCase {
     public void testValidRankerConfig () {
         PersonalizeIntelligentRankerConfiguration rankerConfig =
                 new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, AMAZON_PERSONALIZED_RANKING_RECIPE_NAME, itemIdField, region, weight);
+        ValidationUtil.validatePersonalizeIntelligentRankerConfiguration(rankerConfig, TYPE, TAG);
+    }
+
+    public void testValidRankerConfigPersonalizedRankingV2 () {
+        PersonalizeIntelligentRankerConfiguration rankerConfig =
+                new PersonalizeIntelligentRankerConfiguration(personalizeCampaign, iamRoleArn, AMAZON_PERSONALIZED_RANKING_V2_RECIPE_NAME, itemIdField, region, weight);
         ValidationUtil.validatePersonalizeIntelligentRankerConfiguration(rankerConfig, TYPE, TAG);
     }
 


### PR DESCRIPTION
### Description
Adds PersonalizedRankingV2 recipe to personalize intelligent ranking plugin. Example of change when creating pipeline with the new recipe:
curl -X PUT "http://localhost:9200/_search/pipeline/intelligent_ranking" -u 'admin:admin' --insecure -H 'Content-Type: application/json' -d'
{
"description": "A pipeline to apply custom reranking",
"response_processors" : [
{
"personalized_search_ranking" : {
"campaign_arn" : "arn:aws:personalize:us-east-1:080258283992:campaign/opensearch-campaign",
"item_id_field" : "",
**"recipe" : "aws-personalized-ranking-v2",**
"weight" : "0.25",
"iam_role_arn": "",
"aws_region": "us-east-1"
}
}
]
}'

### Testing
./gradlew build and tested locally by running above command
 
### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/search-processor/blob/main/CONTRIBUTING.md).
